### PR TITLE
Update logging to make it easier to append context and use separate configs for separate loggers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ figwheel_server.log
 .DS_Store
 node_modules/
 data/
+.idea/
+drawknife.iml

--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,16 @@
   :description "Logging configuration & middleware for Starcity projects."
   :url "https://github.com/starcity-properties/drawknife"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [cheshire "5.7.1"]
                  [com.taoensso/timbre "4.10.0"]]
 
   :plugins [[s3-wagon-private "1.2.0"]]
 
-  :repositories {"releases" {:url        "s3://starjars/releases"
-                             :username   :env/aws_access_key
-                             :passphrase :env/aws_secret_key}})
+  :repositories {"releases"  {:url        "s3://starjars/releases"
+                              :username   :env/aws_access_key
+                              :passphrase :env/aws_secret_key}
+                 "snapshots" {:url        "s3://starjars/snapshots"
+                              :username   :env/aws_access_key
+                              :passphrase :env/aws_secret_key}})

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [cheshire "5.7.1"]
-                 [com.taoensso/timbre "4.10.0"]]
+                 [com.taoensso/timbre "4.10.0"]
+                 [nano-id "0.9.3"]]
 
   :plugins [[s3-wagon-private "1.2.0"]]
 

--- a/src/drawknife/core.clj
+++ b/src/drawknife/core.clj
@@ -90,7 +90,6 @@
   is nil, 'data' will be the only output. Potential exception is expected as the
   first element of 'args'."
   [level logger id data & args]
-  (println logger)
   `(let [level#     ~level
          id#        ~id
          log-ctx#   ~logger

--- a/src/drawknife/core.clj
+++ b/src/drawknife/core.clj
@@ -75,8 +75,8 @@
 (defn with
   "Add more context to an existing log context 'log-ctx' by calling 'f' on the
    content of the given log context."
-  [log-ctx f]
-  (update log-ctx :data f))
+  [log-ctx f & args]
+  (apply update log-ctx :data f args))
 
 
 ;; =============================================================================
@@ -92,7 +92,7 @@
   [level log-ctx id data & args]
   `(let [level#     ~level
          id#        ~id
-         throwable# (first ~args)
+         throwable# ~(first args)
          log-data#  (merge ~log-ctx (assoc ~data :millis (System/currentTimeMillis)))]
      (if (some? throwable#)
        (timbre/log level# throwable# id# log-data#)

--- a/src/drawknife/middleware.clj
+++ b/src/drawknife/middleware.clj
@@ -25,8 +25,12 @@
 
   Note: This is needed while the requests is going through the middlewares to have the context
   be included if exceptions would happen. Make sure to use wrap-logger-deref before request
-  is leaving the middlewares and handed off to routes. "
+  is leaving the middlewares and handed off to routes.  "
   [handler]
   (fn [{:keys [deps] :as req}]
     (let [logger (:logger deps (log/timbre-logger :info :println nil))]
       (handler (assoc-in req [:deps :logger] (atom logger))))))
+
+
+(defn something []
+  (log/info {} ::id {:a 1} (ex-info "test" {})))

--- a/src/drawknife/middleware.clj
+++ b/src/drawknife/middleware.clj
@@ -1,36 +1,36 @@
 (ns drawknife.middleware
   (:require
-    [drawknife.core :as log]))
+    [drawknife.core :as log]
+    [nano-id.core :refer [nano-id]]))
 
 
-(defn wrap-logging-ctx
+(defn wrap-logging-atom-ctx
   "Update logger with more context from the request, where 'ctx-keys' are keys in the request,
-  whose values should be includede in the logger."
-  [handler ctx]
-  (fn [{:keys [deps] :as req}]
-    (let [logger-with-ctx (log/with @(:logger deps) #(merge % (ctx req)))]
-      (reset! (:logger deps) logger-with-ctx)
+  whose values should be included in the logger."
+  [handler log-key ctx-fn]
+  (fn [req]
+    (let [logger          (get req log-key)
+          logger-with-ctx (log/with @logger merge (ctx-fn req))]
+      (reset! logger logger-with-ctx)
       (handler req))))
 
 
-(defn wrap-logger-deref
+(defn wrap-logger-atom-deref
   "Middleware to deref the logger before request is handed off to routes."
-  [handler]
+  [handler log-key]
   (fn [req]
-    (handler (update-in req [:deps :logger] deref))))
+    (handler (update req log-key deref))))
 
 
-(defn wrap-logger-atom
-  "Update logger to be an atom.
-
-  Note: This is needed while the requests is going through the middlewares to have the context
-  be included if exceptions would happen. Make sure to use wrap-logger-deref before request
-  is leaving the middlewares and handed off to routes.  "
-  [handler]
-  (fn [{:keys [deps] :as req}]
-    (let [logger (:logger deps (log/timbre-logger :info :println nil))]
-      (handler (assoc-in req [:deps :logger] (atom logger))))))
-
-
-(defn something []
-  (log/info {} ::id {:a 1} (ex-info "test" {})))
+(defn wrap-request-logger-atom
+  "Wrap logger context atom for requests when context need to be kept between middlewares,
+  use wrap-logger-atom-deref to deref the atom"
+  [handler log-key & [{:keys [ctx-fn req-keys init]
+                       :or   {ctx-fn (constantly nil)}}]]
+  (fn [req]
+    (let [ctx    (merge (select-keys req (into [:request-method :uri :url :remote-addr] req-keys))
+                        (ctx-fn req)
+                        {:request-id (nano-id)})
+          logger (log/with (or init (log/timbre-logger :info :println nil))
+                           merge ctx)]
+      (handler (assoc req log-key (atom logger))))))

--- a/src/drawknife/middleware.clj
+++ b/src/drawknife/middleware.clj
@@ -1,0 +1,32 @@
+(ns drawknife.middleware
+  (:require
+    [drawknife.core :as log]))
+
+
+(defn wrap-logging-ctx
+  "Update logger with more context from the request, where 'ctx-keys' are keys in the request,
+  whose values should be includede in the logger."
+  [handler ctx]
+  (fn [{:keys [deps] :as req}]
+    (let [logger-with-ctx (log/with @(:logger deps) #(merge % (ctx req)))]
+      (reset! (:logger deps) logger-with-ctx)
+      (handler req))))
+
+
+(defn wrap-logger-deref
+  "Middleware to deref the logger before request is handed off to routes."
+  [handler]
+  (fn [req]
+    (handler (update-in req [:deps :logger] deref))))
+
+
+(defn wrap-logger-atom
+  "Update logger to be an atom.
+
+  Note: This is needed while the requests is going through the middlewares to have the context
+  be included if exceptions would happen. Make sure to use wrap-logger-deref before request
+  is leaving the middlewares and handed off to routes. "
+  [handler]
+  (fn [{:keys [deps] :as req}]
+    (let [logger (:logger deps (log/timbre-logger :info :println nil))]
+      (handler (assoc-in req [:deps :logger] (atom logger))))))


### PR DESCRIPTION
## Context
To have more context in all our logs, this is adding some functionality to have the context follow with the flow of the application. The use of this currently is as follows:

1. Request comes in, a logger with a certain configuration is added some context to around the request (e.g. url, session etc). 
2. The request causes things to happen around our codebase, where one could use the same logger to log what's happening and automatically have the request context attached.

One could have several loggers with different configurations, although that's not currently in use.

With lack of time on my part, this is a small step towards streamlining our logs and it works as is. It's still a work in progress though.

