### PR TITLE
Timestamp with timezone in log outputs.

### DIFF
--- a/src/drawknife/core.clj
+++ b/src/drawknife/core.clj
@@ -61,9 +61,12 @@
   [log-level appender & [filename]]
   (merge
     (update timbre/example-config :appenders dissoc :println)
-    {:level      log-level
-     :middleware [wrap-event-format]
-     :appenders  (appender-config appender {:filename filename})}))
+    {:level          log-level
+     :timestamp-opts {:pattern  "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                      :locale   :jvm-default
+                      :timezone :utc}
+     :middleware     [wrap-event-format]
+     :appenders      (appender-config appender {:filename filename})}))
 
 
 ;; =============================================================================

--- a/src/drawknife/core.clj
+++ b/src/drawknife/core.clj
@@ -24,8 +24,11 @@
          :params map?))
 
 
-(defn- kebab->snake [s]
-  (string/replace (reduce str (drop 1 (str s))) #"-" "_"))
+(defn- kebab->snake
+  "To snake case, excluding the : character from a keyword."
+  [s]
+  (-> (string/replace (str s) #":(.)" "$1")
+      (string/replace #"[-/.]" "_")))
 
 
 (defn- event-vargs


### PR DESCRIPTION
We have to include the timezone in the log output, replace all weird characters with "_" in JSON keys.