### PR TITLE
Fix parsing errors when incoming message is not valid JSON.

### DIFF
--- a/src/drawknife/core.clj
+++ b/src/drawknife/core.clj
@@ -106,7 +106,12 @@
             :level     (clojure.string/upper-case (name level))
             :ns        (or ?ns-str ?file "?")
             :line      (or ?line "?")
-            :msg       (json/parse-string (force msg_))}
+            :msg       (let [msg (force msg_)]
+                         (try
+                           (json/parse-string msg)
+                           (catch Throwable _
+                             ;; If this is not JSON just return the string as is.
+                             msg)))}
 
            (and (not no-stacktrace?) (some? ?err))
            (merge {:stacktrace (timbre/stacktrace ?err)})))))))


### PR DESCRIPTION
## Context
When messages are not valid JSON, the application would throw errors because of parsing problems. 

This is adding a `try/catch` to avoid that and return the message as is if not valid json